### PR TITLE
Add wrangler config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,13 @@
+compatibility_date = "2023-10-17"
+
+[[services]]
+name = "ingest"
+main = "workers/ingest/index.ts"
+route = "/webhook/gdacs"
+triggers = { crons = ["5 0 * * *"] }
+
+[[services]]
+name = "api"
+main = "workers/api/index.ts"
+route = "/api/*"
+


### PR DESCRIPTION
## Summary
- configure Cloudflare Workers in a new `wrangler.toml`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852f11f62bc832f817ceb43a72d43ab

## Summary by Sourcery

Add a new wrangler.toml to configure Cloudflare Workers by defining two services—ingest and api—with their entry points, routes, and scheduling triggers.

New Features:
- Add wrangler.toml to configure Cloudflare Workers with two services
- Define "ingest" service with route "/webhook/gdacs" and daily cron trigger
- Define "api" service with route "/api/*"