### PR TITLE
Add initial parser stub

### DIFF
--- a/workers/ingest/parser.ts
+++ b/workers/ingest/parser.ts
@@ -1,0 +1,21 @@
+export interface RawEvent {
+  eventId: string;
+  source: string;
+  payload: any;
+}
+
+/**
+ * Parse an inbound MIME email and return a minimal RawEvent object.
+ *
+ * This is a stubbed implementation. The real parser would decode MIME
+ * attachments and body content to build the event payload and enrich it
+ * with metadata like geolocation and severity scores.
+ */
+export async function parseAndEnrich(rawMime: string): Promise<RawEvent> {
+  // TODO: Implement actual MIME parsing and enrichment logic
+  const eventId = `evt_${Date.now()}`;
+  const source = 'unknown';
+  const payload = rawMime;
+
+  return { eventId, source, payload };
+}


### PR DESCRIPTION
## Summary
- set up directory for ingest workers
- add `parseAndEnrich` function returning a stubbed `RawEvent`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852f1515cbc832f86801c81f28f6098

## Summary by Sourcery

Introduce the initial parser stub for the ingest pipeline by defining a RawEvent interface and a placeholder parseAndEnrich function.

New Features:
- Add RawEvent interface for standardized event structure
- Add parseAndEnrich function stub returning a placeholder RawEvent

Chores:
- Set up workers/ingest directory for parser code