### PR TITLE
Implement ParserQueue Durable Object

### DIFF
--- a/workers/ingest/parser-queue.ts
+++ b/workers/ingest/parser-queue.ts
@@ -1,0 +1,57 @@
+import { parseAndEnrich } from './parser';
+
+interface RawEvent {
+  eventId: string;
+  source: string;
+  payload: any;
+}
+
+interface Event {
+  id: string;
+  type: string;
+  timestamp: string;
+  latitude: number;
+  longitude: number;
+  region: string;
+  magnitude?: number;
+  severityScore: number;
+  categories: string[];
+  description: string;
+}
+
+interface ParserQueueEnv {
+  API_URL: string;
+}
+
+export class ParserQueue {
+  private state: DurableObjectState;
+  private env: ParserQueueEnv;
+
+  constructor(state: DurableObjectState, env: ParserQueueEnv) {
+    this.state = state;
+    this.env = env;
+  }
+
+  private async dequeue(): Promise<RawEvent | undefined> {
+    const queue = (await this.state.storage.get<RawEvent[]>('queue')) || [];
+    const job = queue.shift();
+    await this.state.storage.put('queue', queue);
+    return job;
+  }
+
+  async fetch(_req: Request): Promise<Response> {
+    const job = await this.dequeue();
+    if (!job) {
+      return new Response('No job', { status: 204 });
+    }
+
+    const enriched = await parseAndEnrich(job);
+    await fetch(`${this.env.API_URL}/internal/store-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(enriched),
+    });
+
+    return new Response('ok');
+  }
+}

--- a/workers/ingest/parser.ts
+++ b/workers/ingest/parser.ts
@@ -1,0 +1,33 @@
+export interface RawEvent {
+  eventId: string;
+  source: string;
+  payload: any;
+}
+
+export interface Event {
+  id: string;
+  type: string;
+  timestamp: string;
+  latitude: number;
+  longitude: number;
+  region: string;
+  magnitude?: number;
+  severityScore: number;
+  categories: string[];
+  description: string;
+}
+
+export async function parseAndEnrich(event: RawEvent): Promise<Event> {
+  // Placeholder implementation for parse and enrichment logic
+  return {
+    id: event.eventId,
+    type: event.source,
+    timestamp: new Date().toISOString(),
+    latitude: 0,
+    longitude: 0,
+    region: 'unknown',
+    severityScore: 0,
+    categories: [],
+    description: JSON.stringify(event.payload),
+  };
+}


### PR DESCRIPTION
## Summary
- add `ParserQueue` Durable Object in `workers/ingest/parser-queue.ts`
- stub `parseAndEnrich` implementation in `workers/ingest/parser.ts`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852f16bf06c832fb55d60b1568d0658